### PR TITLE
Fix a wrong https link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "main"
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub async fn create_project(path: &str) -> Result<()> {
     info!("  2. Add your GitHub access key to `.env`");
     info!("  3. Fetch initial data: `wallowa fetch` (this can take a while for active repos)");
     info!("  4. Start the server: `wallowa serve`");
-    info!("  5. Open your browser to https://localhost:9843/");
+    info!("  5. Open your browser to http://localhost:9843/");
     info!("");
     info!("Check out the documentation at https://localhost:9843/docs/ or https://www.wallowa.io/docs/");
     info!("");


### PR DESCRIPTION
Without this fix, the link the CLI proposes results in the following
<img width="855" alt="image" src="https://github.com/gunrein/wallowa/assets/173663/96cc1b5b-401e-4538-a7ee-accef4d82b70">
